### PR TITLE
Make ShardsDB#search case insensitive

### DIFF
--- a/src/db.cr
+++ b/src/db.cr
@@ -506,7 +506,7 @@ class ShardsDB
       LEFT JOIN
         shard_metrics_current AS metrics ON metrics.shard_id = shards.id
       WHERE
-        name LIKE $1 OR qualifier LIKE $1 OR shards.description LIKE $1 OR releases.spec->>'description' = $1 OR repos.metadata->>'description' = $1
+        name ILIKE $1 OR qualifier ILIKE $1 OR shards.description ILIKE $1 OR releases.spec->>'description' = $1 OR repos.metadata->>'description' = $1
       ORDER BY
         metrics.popularity DESC
       LIMIT 100


### PR DESCRIPTION
Fixes #5

This is the SQL standard way, but if you are using PostgreSQL we could just change `LIKE` to `ILIKE`.